### PR TITLE
Use scroll wheel to change throwing distance

### DIFF
--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -251,7 +251,7 @@ MonoBehaviour:
   cubePrefab: {fileID: 3724625305731320972, guid: 545df75989fe9d44e98440bdd26f1aac, type: 3}
   throwForce: 15
   throwHeight: 0.5
-  maxThrowDistance: 10
+  landingIndicatorSize: 1
   throwSpinSpeed: 3
   cubeSpawnPoint: {fileID: 462428314}
   defaultSpawnOffset: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Player/ThrowItem.cs
+++ b/Assets/Scripts/Player/ThrowItem.cs
@@ -8,7 +8,7 @@ public class ThrowItem : MonoBehaviour
     [SerializeField] private GameObject cubePrefab;
     [SerializeField] private float throwForce = 20f;
     [SerializeField] private float throwHeight = 1.5f;
-    [SerializeField] private float maxThrowDistance = 50f;
+    [SerializeField] private float landingIndicatorSize = 1f;
     [SerializeField] private float throwSpinSpeed = 3f;  // 投掷时旋转角速度，可在 Inspector 调整
 
     [Header("Position settings")]
@@ -33,6 +33,7 @@ public class ThrowItem : MonoBehaviour
     private Vector3 throwDirection;              
 
     InputAction throwAction;
+    InputAction changeThrowDistance;
 
     private void Start()
     {
@@ -41,6 +42,7 @@ public class ThrowItem : MonoBehaviour
             cameraTransform = mainCam.transform;
 
         throwAction = InputSystem.actions.FindAction("Throw");
+        changeThrowDistance = InputSystem.actions.FindAction("Change throw distance");
 
         if (cubeSpawnPoint == null)
         {
@@ -129,15 +131,16 @@ public class ThrowItem : MonoBehaviour
     private void Update()
     {
         if (throwAction.WasPressedThisFrame())
-        {
             StartHolding();
-        }
 
         if (throwAction.IsPressed() && isHoldingRightClick)
             UpdateHolding();
 
         if (throwAction.WasReleasedThisFrame() && isHoldingRightClick)
             StartThrowing();
+
+        if (throwAction.IsPressed())
+            throwForce += changeThrowDistance.ReadValue<Vector2>().y * 0.5f;
     }
 
     private void StartHolding()
@@ -238,7 +241,7 @@ public class ThrowItem : MonoBehaviour
         landingIndicator.transform.Rotate(90f, 0f, 0f);
 
         float distance = Vector3.Distance(position, cameraTransform.position);
-        float scale = Mathf.Lerp(0.3f, 1.5f, distance / maxThrowDistance);
+        float scale = Mathf.Lerp(0.3f, 1.5f, distance * landingIndicatorSize / 50);
         landingIndicator.transform.localScale = new Vector3(scale, 0.05f, scale);
     }
 

--- a/Assets/Settings/InputSystem_Actions.inputactions
+++ b/Assets/Settings/InputSystem_Actions.inputactions
@@ -43,46 +43,28 @@
                     "initialStateCheck": true
                 },
                 {
+                    "name": "Change throw distance",
+                    "type": "Value",
+                    "id": "cb69f60e-ed8a-4e26-8582-51f23c1a9e20",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
                     "name": "Interact",
                     "type": "Button",
                     "id": "852140f2-7766-474d-8707-702459ba45f3",
-                    "expectedControlType": "Button",
+                    "expectedControlType": "",
                     "processors": "",
                     "interactions": "Hold",
-                    "initialStateCheck": false
-                },
-                {
-                    "name": "Crouch",
-                    "type": "Button",
-                    "id": "27c5f898-bc57-4ee1-8800-db469aca5fe3",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "",
                     "initialStateCheck": false
                 },
                 {
                     "name": "Jump",
                     "type": "Button",
                     "id": "f1ba0d36-48eb-4cd5-b651-1c94a6531f70",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
-                },
-                {
-                    "name": "Previous",
-                    "type": "Button",
-                    "id": "2776c80d-3c14-4091-8c56-d04ced07a2b0",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
-                },
-                {
-                    "name": "Next",
-                    "type": "Button",
-                    "id": "b7230bb6-fc9b-4f52-8b25-f5e19cb2c2ba",
-                    "expectedControlType": "Button",
+                    "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
@@ -91,7 +73,7 @@
                     "name": "Sprint",
                     "type": "Button",
                     "id": "641cd816-40e6-41b4-8c3d-04687c349290",
-                    "expectedControlType": "Button",
+                    "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
@@ -369,28 +351,6 @@
                 },
                 {
                     "name": "",
-                    "id": "cbac6039-9c09-46a1-b5f2-4e5124ccb5ed",
-                    "path": "<Keyboard>/2",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Keyboard&Mouse",
-                    "action": "Next",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "e15ca19d-e649-4852-97d5-7fe8ccc44e94",
-                    "path": "<Gamepad>/dpad/right",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Gamepad",
-                    "action": "Next",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "f2e9ba44-c423-42a7-ad56-f20975884794",
                     "path": "<Keyboard>/leftShift",
                     "interactions": "",
@@ -457,28 +417,6 @@
                 },
                 {
                     "name": "",
-                    "id": "1534dc16-a6aa-499d-9c3a-22b47347b52a",
-                    "path": "<Keyboard>/1",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Keyboard&Mouse",
-                    "action": "Previous",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "25060bbd-a3a6-476e-8fba-45ae484aad05",
-                    "path": "<Gamepad>/dpad/left",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Gamepad",
-                    "action": "Previous",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "1c04ea5f-b012-41d1-a6f7-02e963b52893",
                     "path": "<Keyboard>/e",
                     "interactions": "",
@@ -496,28 +434,6 @@
                     "processors": "",
                     "groups": "Gamepad",
                     "action": "Interact",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "4f4649ac-64a8-4a73-af11-b3faef356a4d",
-                    "path": "<Gamepad>/buttonEast",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Gamepad",
-                    "action": "Crouch",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "36e52cba-0905-478e-a818-f4bfcb9f3b9a",
-                    "path": "<Keyboard>/c",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Keyboard&Mouse",
-                    "action": "Crouch",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -584,6 +500,17 @@
                     "processors": "",
                     "groups": ";Keyboard&Mouse",
                     "action": "Echolocate",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "92c0880a-8caf-41d0-85df-f123886296c2",
+                    "path": "<Mouse>/scroll",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Change throw distance",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }


### PR DESCRIPTION
# Pull Request

Fixes #56 

## Main description

Adds scroll wheel controls to throwing mechanic.
Moving scroll wheel increases/decreases force of throw
Removes input actions that aren't used/needed
Renames `maxThrowDistance` to `landingIndicatorSize` to reflect the effect it has in-game, and change arithmetic calculating the landing indicator size so that higher value = greater size
