### PR TITLE
Heartbeat

### DIFF
--- a/Assets/Audio/Sound effects/heartbeat.mp3
+++ b/Assets/Audio/Sound effects/heartbeat.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71e2d9e16443a16e65356898b72bf13a055403fd7745b9ff086cfcd52d6435ec
+size 18852

--- a/Assets/Audio/Sound effects/heartbeat.mp3.meta
+++ b/Assets/Audio/Sound effects/heartbeat.mp3.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 1354edae52a2a664ba0d7429fafdb139
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/BETA.unity
+++ b/Assets/Scenes/BETA.unity
@@ -277,6 +277,11 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 45905327973127387, guid: 18ee8a411025b184d837691a31335d91, type: 3}
   m_PrefabInstance: {fileID: 2052217932}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &313540093 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 576453552342798947, guid: 0154bc25b91f91944a4eb7678daebf2b, type: 3}
+  m_PrefabInstance: {fileID: 1490969044}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &334442236 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -3371461047000612559, guid: 0db051784510c0a47b3267eef9f1e03c, type: 3}
@@ -2403,7 +2408,13 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5235627052445221193, guid: 9719fd3b76bb0794a98a0fddd7542603, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2106793542126640628}
+    - targetCorrespondingSourceObject: {fileID: 5235627052445221193, guid: 9719fd3b76bb0794a98a0fddd7542603, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2106793542126640627}
   m_SourcePrefab: {fileID: 100100000, guid: 9719fd3b76bb0794a98a0fddd7542603, type: 3}
 --- !u!1 &2106793542126640619 stripped
 GameObject:
@@ -2442,6 +2453,130 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3853411543216132462, guid: 9719fd3b76bb0794a98a0fddd7542603, type: 3}
   m_PrefabInstance: {fileID: 2106793542126640618}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2106793542126640627
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2106793542126640619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8901822d010e6384ea8fd981fcbb492b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  monsterTransforms:
+  - {fileID: 313540093}
+  heartbeatClip: {fileID: 8300000, guid: 1354edae52a2a664ba0d7429fafdb139, type: 3}
+  audioSource: {fileID: 0}
+  maxDistance: 20
+  mediumDistance: 10
+  closeDistance: 5
+  slowVolume: 0.35
+  slowPitch: 0.75
+  mediumVolume: 0.6
+  mediumPitch: 1
+  fastVolume: 0.9
+  fastPitch: 1.35
+  smoothSpeed: 12
+  updateInterval: 0.1
+--- !u!82 &2106793542126640628
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2106793542126640619}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/PlayerHeartbeat.cs
+++ b/Assets/Scripts/Player/PlayerHeartbeat.cs
@@ -1,0 +1,126 @@
+using UnityEngine;
+
+[RequireComponent(typeof(AudioSource))]
+public class PlayerHeartbeat : MonoBehaviour
+{
+    [Header("Monster Source")]
+    public Transform[] monsterTransforms;
+
+    [Header("Heartbeat Audio")]
+    public AudioClip heartbeatClip;
+    public AudioSource audioSource;
+
+    [Header("Distance Thresholds (m)")]
+    public float maxDistance = 20f;
+    public float mediumDistance = 10f;
+    public float closeDistance = 5f;
+
+    [Header("Slow (20m ~ 10m)")]
+    [Range(0f, 1f)] public float slowVolume = 0.35f;
+    [Range(0.5f, 2f)] public float slowPitch = 0.75f;
+
+    [Header("Medium (10m ~ 5m)")]
+    [Range(0f, 1f)] public float mediumVolume = 0.6f;
+    [Range(0.5f, 2f)] public float mediumPitch = 1f;
+
+    [Header("Fast (within 5m)")]
+    [Range(0f, 1f)] public float fastVolume = 0.9f;
+    [Range(0.5f, 2f)] public float fastPitch = 1.35f;
+
+    [Header("Smoothing")]
+    [Range(1f, 30f)] public float smoothSpeed = 12f;
+    [Range(0.02f, 0.5f)] public float updateInterval = 0.1f;
+
+    float _targetVolume;
+    float _targetPitch;
+    float _nextUpdateTime;
+    bool _wasInRange;
+
+    void Awake()
+    {
+        if (audioSource == null)
+            audioSource = GetComponent<AudioSource>();
+        if (audioSource != null)
+        {
+            audioSource.loop = true;
+            audioSource.playOnAwake = false;
+            audioSource.clip = heartbeatClip;
+        }
+        _targetVolume = 0f;
+        _targetPitch = slowPitch;
+    }
+
+    void Update()
+    {
+        if (heartbeatClip == null || audioSource == null) return;
+
+        if (Time.time >= _nextUpdateTime)
+        {
+            _nextUpdateTime = Time.time + updateInterval;
+            float closestDist = GetClosestMonsterDistance();
+            UpdateTargetParams(closestDist);
+        }
+
+        audioSource.volume = Mathf.MoveTowards(audioSource.volume, _targetVolume, smoothSpeed * Time.deltaTime);
+        audioSource.pitch = Mathf.MoveTowards(audioSource.pitch, _targetPitch, smoothSpeed * Time.deltaTime);
+
+        if (_targetVolume > 0.001f)
+        {
+            if (!audioSource.isPlaying)
+                audioSource.Play();
+        }
+        else
+        {
+            if (audioSource.isPlaying && audioSource.volume < 0.01f)
+                audioSource.Stop();
+        }
+    }
+
+    float GetClosestMonsterDistance()
+    {
+        if (monsterTransforms == null || monsterTransforms.Length == 0) return float.MaxValue;
+
+        Vector3 playerPos = transform.position;
+        float minSq = float.MaxValue;
+        foreach (var t in monsterTransforms)
+        {
+            if (t == null) continue;
+            float sq = (t.position - playerPos).sqrMagnitude;
+            if (sq < minSq) minSq = sq;
+        }
+        return minSq == float.MaxValue ? float.MaxValue : Mathf.Sqrt(minSq);
+    }
+
+    void UpdateTargetParams(float distance)
+    {
+        if (distance > maxDistance)
+        {
+            _targetVolume = 0f;
+            _targetPitch = slowPitch;
+            _wasInRange = false;
+            return;
+        }
+
+        _wasInRange = true;
+        if (distance <= closeDistance)
+        {
+            _targetVolume = fastVolume;
+            _targetPitch = fastPitch;
+        }
+        else if (distance <= mediumDistance)
+        {
+            _targetVolume = mediumVolume;
+            _targetPitch = mediumPitch;
+        }
+        else
+        {
+            _targetVolume = slowVolume;
+            _targetPitch = slowPitch;
+        }
+    }
+
+    public void SetMonsterTransforms(Transform[] monsters)
+    {
+        monsterTransforms = monsters;
+    }
+}

--- a/Assets/Scripts/Player/PlayerHeartbeat.cs.meta
+++ b/Assets/Scripts/Player/PlayerHeartbeat.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8901822d010e6384ea8fd981fcbb492b


### PR DESCRIPTION
# Pull Request

Fixes #174 

## Main description

This PR adds a heartbeat audio system that plays when the monster is close to the player.

The heartbeat changes based on the distance between the monster and the player:
- slow when the monster is within 20m
- medium when the monster is within 10m
- fast when the monster is within 5m

This was added to improve tension and give the player clearer audio feedback when the monster is nearby.
## Additional information

The distance thresholds, volume, and speed can be adjusted in the Inspector.
