### PR TITLE
Extra monster echolocation features

### DIFF
--- a/Assets/Prefabs/Echolocation/EcholocationSystem.prefab
+++ b/Assets/Prefabs/Echolocation/EcholocationSystem.prefab
@@ -48,7 +48,7 @@ MonoBehaviour:
   raysPerScan: 20000
   scanLayers:
     serializedVersion: 2
-    m_Bits: 2094463
+    m_Bits: 2094591
   soundSpeed: 100
   useSoundPropagation: 1
   volumeLossPerMeter: 2

--- a/Assets/Prefabs/Echolocation/GlobalEchoSystem.prefab
+++ b/Assets/Prefabs/Echolocation/GlobalEchoSystem.prefab
@@ -84,3 +84,6 @@ MonoBehaviour:
   pillBoxLayer:
     serializedVersion: 2
     m_Bits: 524288
+  playerLayer:
+    serializedVersion: 2
+    m_Bits: 128

--- a/Assets/Scenes/FINAL.unity
+++ b/Assets/Scenes/FINAL.unity
@@ -33634,6 +33634,10 @@ PrefabInstance:
       propertyPath: agent
       value: 
       objectReference: {fileID: 1490969045}
+    - target: {fileID: 5017795408981396545, guid: a4e32bb7c5f5c1249906747df595911f, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5054393201015643135, guid: a4e32bb7c5f5c1249906747df595911f, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/Scripts/Behaviour/PingEchoNoSoundAction.cs
+++ b/Assets/Scripts/Behaviour/PingEchoNoSoundAction.cs
@@ -28,7 +28,7 @@ public partial class PingEchoNoSoundAction : Action
 
     protected override Status OnStart()
     {
-        GlobalEchoSystem.Ping(Agent.Value, Agent.Value.transform.position + positionOffset, Agent.Value.transform.forward, angle, uniformity, numRays, visualVolume, monsterVolume);
+        GlobalEchoSystem.Ping(Agent.Value, Agent.Value.transform.position + positionOffset, Agent.Value.transform.forward, angle, uniformity, numRays, visualVolume, monsterVolume, isMonsterEcholocation: true);
         return Status.Running;
     }
 

--- a/Assets/Scripts/Behaviour/PingGlobalEchoSystemAction.cs
+++ b/Assets/Scripts/Behaviour/PingGlobalEchoSystemAction.cs
@@ -38,7 +38,7 @@ public partial class PingGlobalEchoSystemAction : Action
         if (soundNum == 1) audioSource.Value.PlayOneShot(sound1, soundVolume);
         if (soundNum == 2) audioSource.Value.PlayOneShot(sound2, soundVolume);
 
-        GlobalEchoSystem.Ping(Agent.Value, Agent.Value.transform.position + positionOffset, Agent.Value.transform.forward, angle, uniformity, numRays, visualVolume, monsterVolume);
+        GlobalEchoSystem.Ping(Agent.Value, Agent.Value.transform.position + positionOffset, Agent.Value.transform.forward, angle, uniformity, numRays, visualVolume, monsterVolume, isMonsterEcholocation: true);
         return Status.Running;
     }
 

--- a/Assets/Scripts/Echolocation/EcholocationManager.cs
+++ b/Assets/Scripts/Echolocation/EcholocationManager.cs
@@ -126,6 +126,10 @@ public class EcholocationManager : MonoBehaviour
     // Tells monster if it's a footstep sound
     private bool isFootstepsScan = false;
 
+    // Lets system know if the monster is the thing that produced this instance of echolcation,
+    // makes all dots red and alerts monster if it hits the player
+    bool isMonsterEcho = false;
+
     // Layer memory - to restore object+children's layers, after setting to IgnoreRaycast layer on first pulse, and reset before first reflections
     private Dictionary<Transform, int> layerMemory = new Dictionary<Transform, int>();
 
@@ -248,7 +252,7 @@ public class EcholocationManager : MonoBehaviour
     }
 
     // Defaults to uniform rays
-    public void SetupScan(GameObject ignoreMe, Vector3 direction, float angle, float uniformity = 1.0f, int numRays = 4000, float visualVolume = 10f, float monsterVolume = 10f, bool isFootsteps = false, NativeHashMap<int, int> colorMap = default, float priority = 1f)
+    public void SetupScan(GameObject ignoreMe, Vector3 direction, float angle, float uniformity = 1.0f, int numRays = 4000, float visualVolume = 10f, float monsterVolume = 10f, bool isFootsteps = false, NativeHashMap<int, int> colorMap = default, float priority = 1f, bool isMonsterEcholocation = false)
     {
         // Check to prevent LookRotation(0,0,0) errors
         if (direction.sqrMagnitude < 0.001f) direction = Vector3.forward;
@@ -262,6 +266,7 @@ public class EcholocationManager : MonoBehaviour
         initialVisualVolume = visualVolume;
         initialMonsterVolume = monsterVolume;
         isFootstepsScan = isFootsteps;
+        isMonsterEcho = isMonsterEcholocation;
 
         // FIXME: remove this when multiple ray bounces have been implemented
         // for now just make the monster hear the sound
@@ -316,6 +321,8 @@ public class EcholocationManager : MonoBehaviour
     // Fires the rays
     void PerformScan()
     {
+        // If it's a monster echolocation and it "sees" the player set to true
+        bool monsterSeenPlayer = false;
 
         GameObject sourceObj = (objectToIgnore != null) ? objectToIgnore : this.gameObject;
 
@@ -428,23 +435,37 @@ public class EcholocationManager : MonoBehaviour
 
                     instanceMatrices[globalIndex] = vHit.matrix;
 
-                    // Assign colour
-                    Color baseColor = vHit.colorCategory switch
+                    // If the monster produced the echolocation and the rays hit the player (using player category) alert monster
+                    if (isMonsterEcho && (vHit.colorCategory == 13))
                     {
-                        1 => monsterColors[vHit.colorVariant],
-                        2 => interactableColors[vHit.colorVariant],
-                        3 => metalColors[vHit.colorVariant],
-                        4 => dirtColors[vHit.colorVariant],
-                        5 => woodColors[vHit.colorVariant],
-                        6 => labColors[vHit.colorVariant],
-                        7 => railColors[vHit.colorVariant],
-                        8 => hideRockColors[vHit.colorVariant],
-                        9 => waterColors[vHit.colorVariant],
-                        10 => batColors[vHit.colorVariant],
-                        11 => keyColors[vHit.colorVariant],
-                        12 => pillBoxColors[vHit.colorVariant],
-                        _ => defaultColors[vHit.colorVariant]
-                    };
+                        monsterSeenPlayer = true;
+                    }
+
+                    // Assign colour
+                    Color baseColor;
+                    if (isMonsterEcho) // If monster produced this instance of echolocation make all dots red
+                    {
+                        baseColor = monsterColors[vHit.colorVariant];
+                    }
+                    else
+                    {
+                        baseColor = vHit.colorCategory switch
+                        {
+                            1 => monsterColors[vHit.colorVariant],
+                            2 => interactableColors[vHit.colorVariant],
+                            3 => metalColors[vHit.colorVariant],
+                            4 => dirtColors[vHit.colorVariant],
+                            5 => woodColors[vHit.colorVariant],
+                            6 => labColors[vHit.colorVariant],
+                            7 => railColors[vHit.colorVariant],
+                            8 => hideRockColors[vHit.colorVariant],
+                            9 => waterColors[vHit.colorVariant],
+                            10 => batColors[vHit.colorVariant],
+                            11 => keyColors[vHit.colorVariant],
+                            12 => pillBoxColors[vHit.colorVariant],
+                            _ => defaultColors[vHit.colorVariant]
+                        };
+                    }
 
                     float normalisedVolume = Mathf.Clamp01(vHit.hitVolume / maxPossibleVolume); // Clamped to 1 if hit volume > maxPossibleVolume - starts at max brightness
 
@@ -497,6 +518,13 @@ public class EcholocationManager : MonoBehaviour
                 // Swap to next generation
                 currentRays = nextRays;
             }
+        }
+
+        // If monster echo and "seen" player - actually alert the monster
+        if (monsterSeenPlayer)
+        {
+            // TODO: method to actually alert Monster
+            Debug.Log("Monster has seen the Player");
         }
 
         // Final cleanup

--- a/Assets/Scripts/Echolocation/EcholocationManager.cs
+++ b/Assets/Scripts/Echolocation/EcholocationManager.cs
@@ -323,6 +323,8 @@ public class EcholocationManager : MonoBehaviour
     {
         // If it's a monster echolocation and it "sees" the player set to true
         bool monsterSeenPlayer = false;
+        // Count number of hits
+        int monsterSeenPlayerHits = 0;
 
         GameObject sourceObj = (objectToIgnore != null) ? objectToIgnore : this.gameObject;
 
@@ -422,24 +424,32 @@ public class EcholocationManager : MonoBehaviour
 
                 // --- Assign colours (main thread unpacking) ---
                 int currentBounceHits = visualHits.Length;
+                int renderedHitsThisBounce = 0; // Track valid hits to prevent gaps in GPU arrays - player hits aren't rendered
 
                 // Unpack visual data and assign colours
                 for (int k  = 0; k < currentBounceHits; k++)
                 {
                     VisualHit vHit = visualHits[k];
 
-                    // Use global index so bounce 1 doesn't overwrite bounce 0
-                    int globalIndex = activeHitCount + k;
-
-                    if (globalIndex >= instanceMatrices.Length) break; // Safety if goes past safeBufferSize
-
-                    instanceMatrices[globalIndex] = vHit.matrix;
-
                     // If the monster produced the echolocation and the rays hit the player (using player category) alert monster
                     if (isMonsterEcho && (vHit.colorCategory == 13))
                     {
                         monsterSeenPlayer = true;
+                        monsterSeenPlayerHits++;
                     }
+
+                    // Skip this hit if it was a player hit so that it is not rendered
+                    if (vHit.colorCategory == 13)
+                    {
+                        continue;
+                    }
+
+                    // Use global index so bounce 1 doesn't overwrite bounce 0
+                    int globalIndex = activeHitCount + renderedHitsThisBounce;
+
+                    if (globalIndex >= instanceMatrices.Length) break; // Safety if goes past safeBufferSize
+
+                    instanceMatrices[globalIndex] = vHit.matrix;
 
                     // Assign colour
                     Color baseColor;
@@ -476,9 +486,11 @@ public class EcholocationManager : MonoBehaviour
 
                     // Calculate reveal time
                     instanceRevealTimes[globalIndex] = useSoundPropagation ? vHit.travelDistance / soundSpeed : 0f;
+
+                    renderedHitsThisBounce++;
                 }
 
-                activeHitCount += currentBounceHits;
+                activeHitCount += renderedHitsThisBounce;
                         
                 //TODO: add this when we have multiple ray bounces working
                 // Get the hit with the highest volume - makes the most sense for the monster to be interested in
@@ -524,7 +536,7 @@ public class EcholocationManager : MonoBehaviour
         if (monsterSeenPlayer)
         {
             // TODO: method to actually alert Monster - Just give the player current location instead of ray hitpoint?
-            Debug.Log("Monster has seen the Player");
+            Debug.Log("Monster has seen the player with " + monsterSeenPlayerHits + " hits");
         }
 
         // Final cleanup

--- a/Assets/Scripts/Echolocation/EcholocationManager.cs
+++ b/Assets/Scripts/Echolocation/EcholocationManager.cs
@@ -523,7 +523,7 @@ public class EcholocationManager : MonoBehaviour
         // If monster echo and "seen" player - actually alert the monster
         if (monsterSeenPlayer)
         {
-            // TODO: method to actually alert Monster
+            // TODO: method to actually alert Monster - Just give the player current location instead of ray hitpoint?
             Debug.Log("Monster has seen the Player");
         }
 

--- a/Assets/Scripts/Echolocation/EcholocationManager.cs
+++ b/Assets/Scripts/Echolocation/EcholocationManager.cs
@@ -532,11 +532,18 @@ public class EcholocationManager : MonoBehaviour
             }
         }
 
-        // If monster echo and "seen" player - actually alert the monster
-        if (monsterSeenPlayer)
+        // If monster echo, send the number of rays the hit the player to the monster - even if 0
+        if (isMonsterEcho)
         {
-            // TODO: method to actually alert Monster - Just give the player current location instead of ray hitpoint?
-            Debug.Log("Monster has seen the player with " + monsterSeenPlayerHits + " hits");
+            // Debug.Log("Monster has seen the player with " + monsterSeenPlayerHits + " hits");
+
+            GameObject monster = GameObject.Find("Monster");
+            IEchoSeesPlayerSensitive sensitiveTarget = monster.GetComponent<IEchoSeesPlayerSensitive>();
+
+            if (sensitiveTarget != null)
+            {
+                sensitiveTarget.OnMonsterEcholocation(monsterSeenPlayerHits);
+            }
         }
 
         // Final cleanup

--- a/Assets/Scripts/Echolocation/GlobalEchoSystem.cs
+++ b/Assets/Scripts/Echolocation/GlobalEchoSystem.cs
@@ -131,6 +131,7 @@ public class GlobalEchoSystem : MonoBehaviour
     public LayerMask waterLayer;
     public LayerMask keyLayer;
     public LayerMask pillBoxLayer;
+    public LayerMask playerLayer;
 
     void Start()
     {
@@ -166,6 +167,7 @@ public class GlobalEchoSystem : MonoBehaviour
         if ((batLayer.value & layerMask) > 0) return 10;            // Bat
         if ((keyLayer.value & layerMask) > 0) return 11;            // Key
         if ((pillBoxLayer.value & layerMask) > 0) return 12;        // Pill Box
+        if ((playerLayer.value & layerMask) > 0) return 13;         // Player
         return 0;                                                   // Default
     }
 

--- a/Assets/Scripts/Echolocation/GlobalEchoSystem.cs
+++ b/Assets/Scripts/Echolocation/GlobalEchoSystem.cs
@@ -47,12 +47,12 @@ public class GlobalEchoSystem : MonoBehaviour
     // angle: (takes a value 0-360 degrees) the angle around direction to spawn rays within, e.g. 0 = along the line, 60 = a cone around the line, 360 = a complete sphere
     // uniformity: (takes a value 0-1) how clumped around the directino line rays should be, 0 = clumped completely, 1 = completely uniform. 1 used for spheres for uniform projection in all directions, for cones etc. clumped = 0 gives a more realistic sound effect (sound dies out futher from main direction)
     // numRays: number of rays to spawn
-    public static void Ping(GameObject sourceObject, Vector3 position, Vector3 direction, float angle, float uniformity, int numRays, float visualVolume, float monsterVolume, bool isFootsteps = false, float priority = 1) // Can add things later like: shape of projection + rotation, loudness, pitch, num rays (if not dependent on other things), etc.
+    public static void Ping(GameObject sourceObject, Vector3 position, Vector3 direction, float angle, float uniformity, int numRays, float visualVolume, float monsterVolume, bool isFootsteps = false, float priority = 1, bool isMonsterEcholocation = false) // Can add things later like: shape of projection + rotation, loudness, pitch, num rays (if not dependent on other things), etc.
     {
         // Safety check for existence of GlobalEchoSystem and EcholocationSystem.prefab (via GlobalEchoManager GameObject) 
         if (Instance != null && Instance.echoSystemPrefab != null)
         {
-            Instance.SpawnPulse(sourceObject, position, direction, angle, uniformity, numRays, visualVolume, monsterVolume, isFootsteps, priority);
+            Instance.SpawnPulse(sourceObject, position, direction, angle, uniformity, numRays, visualVolume, monsterVolume, isFootsteps, priority, isMonsterEcholocation);
         }
         else
         {
@@ -61,7 +61,7 @@ public class GlobalEchoSystem : MonoBehaviour
     }
 
     // Takes in an angle between 0 and 360 degrees for shape of projection, and direction for direction to project in  
-    void SpawnPulse(GameObject sourceObject, Vector3 position, Vector3 direction, float angle, float uniformity, int numRays, float visualVolume, float monsterVolume, bool isFootsteps, float priority = 1)
+    void SpawnPulse(GameObject sourceObject, Vector3 position, Vector3 direction, float angle, float uniformity, int numRays, float visualVolume, float monsterVolume, bool isFootsteps, float priority = 1, bool isMonsterEcholocation = false)
     {
         GameObject pulse = Instantiate(echoSystemPrefab, position, Quaternion.identity); // Create (Instantiate) an instance of the EcholocationSystem.prefab at position, with rotation ... (identity means no rotation)
 
@@ -77,7 +77,7 @@ public class GlobalEchoSystem : MonoBehaviour
 
         if (manager != null)
         {
-            manager.SetupScan(sourceObject, direction, angle, uniformity, numRays, visualVolume, monsterVolume, isFootsteps, colliderColorMap, priority);
+            manager.SetupScan(sourceObject, direction, angle, uniformity, numRays, visualVolume, monsterVolume, isFootsteps, colliderColorMap, priority, isMonsterEcholocation);
         }
     }
 

--- a/Assets/Scripts/Echolocation/IEchoSeesPlayerSensitive.cs
+++ b/Assets/Scripts/Echolocation/IEchoSeesPlayerSensitive.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+// Public interface for informing Monster of the number of rays that hit the player when it echolocates
+public interface IEchoSeesPlayerSensitive
+{
+    void OnMonsterEcholocation(int monsterSeenPlayerHits);
+} 

--- a/Assets/Scripts/Echolocation/IEchoSeesPlayerSensitive.cs.meta
+++ b/Assets/Scripts/Echolocation/IEchoSeesPlayerSensitive.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 207e3859a51e47a469653b0698e1c73e

--- a/Assets/Scripts/Monster/Hearing.cs
+++ b/Assets/Scripts/Monster/Hearing.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class HearingChecker : MonoBehaviour, INoiseSensitive
+public class HearingChecker : MonoBehaviour, INoiseSensitive, IEchoSeesPlayerSensitive
 {
     public float maxSoundDistance = 30f;
     public float AgentEyeHeight = 3.9f;
@@ -34,6 +34,11 @@ public class HearingChecker : MonoBehaviour, INoiseSensitive
                 newSource.isFootsteps = isFootsteps;
             }
         }
+    }
+
+    public void OnMonsterEcholocation(int monsterSeenPlayerHits)
+    {
+        Debug.Log("Monster seen player hits: " + monsterSeenPlayerHits);
     }
 
     // called every frame by monster behaviour tree to check for new sounds

--- a/Assets/Scripts/Monster/Hearing.cs
+++ b/Assets/Scripts/Monster/Hearing.cs
@@ -38,7 +38,7 @@ public class HearingChecker : MonoBehaviour, INoiseSensitive, IEchoSeesPlayerSen
 
     public void OnMonsterEcholocation(int monsterSeenPlayerHits)
     {
-        Debug.Log("Monster seen player hits: " + monsterSeenPlayerHits);
+        // Debug.Log("Monster seen player hits: " + monsterSeenPlayerHits);
     }
 
     // called every frame by monster behaviour tree to check for new sounds

--- a/Assets/Scripts/Monster/MonsterFootsteps.cs
+++ b/Assets/Scripts/Monster/MonsterFootsteps.cs
@@ -118,6 +118,6 @@ public class MonsterFootsteps : MonoBehaviour
         float visualVolume = currentSettings.maxDistance * 2f;
         // Trigger Echo
         // We use footPos as origin, and transform.forward for direction (though if angle is 360, direction doesn't matter)
-        GlobalEchoSystem.Ping(this.gameObject, footPos, transform.forward, echoAngle, 0.3f, currentSettings.echoRays, visualVolume, currentSettings.volForMonster, true);
+        GlobalEchoSystem.Ping(this.gameObject, footPos, transform.forward, echoAngle, 0.3f, currentSettings.echoRays, visualVolume, currentSettings.volForMonster, true, isMonsterEcholocation: true);
     }
 }


### PR DESCRIPTION
Made it so that all monster echolocation is red, such as its clicking noise and footsteps, via boolean input when Ping is called.
Added functionality via boolean and interface that passes the number of rays from the monster that hit the player to the monster in hearing.cs - currently a "Debug only" implementation that outputs the number to check it works.
For this, the player layer was added to the layermask for echolocation so that rays can actually hit them, but logic was added that prevented these hits from being visualised to prevent on screen clutter for the user.